### PR TITLE
Fix for transaction message truncate 

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -21,7 +21,10 @@ from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
-from .....payment.utils import create_manual_adjustment_events, truncate_message
+from .....payment.utils import (
+    create_manual_adjustment_events,
+    truncate_transaction_event_message,
+)
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
@@ -288,9 +291,10 @@ class TransactionCreate(BaseMutation):
         app_identifier = None
         if app and app.identifier:
             app_identifier = app.identifier
+        message = transaction_event_input.get("message") or ""
         return transaction.events.create(
             psp_reference=transaction_event_input.get("psp_reference"),
-            message=truncate_message(transaction_event_input.get("message", "")),
+            message=truncate_transaction_event_message(message),
             transaction=transaction,
             user=user if user and user.is_authenticated else None,
             app_identifier=app_identifier,

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -26,7 +26,7 @@ from .....payment.utils import (
     create_failed_transaction_event,
     get_already_existing_event,
     get_transaction_event_amount,
-    truncate_message,
+    truncate_transaction_event_message,
 )
 from .....permission.auth_filters import AuthorizationFilters
 from .....permission.enums import PaymentPermissions
@@ -332,7 +332,9 @@ class TransactionEventReport(ModelMutation):
                 psp_reference, transaction
             )
 
-        message = truncate_message(message) if message is not None else ""
+        message = (
+            truncate_transaction_event_message(message) if message is not None else ""
+        )
         transaction_event_data = {
             "psp_reference": psp_reference,
             "type": type,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -3229,3 +3229,83 @@ def test_transaction_event_report_message_limit_exceeded(
     assert event.app == app_api_client.app
     assert event.user is None
     assert event.message == message[:509] + "..."
+
+
+def test_transaction_event_report_empty_message(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal("10")
+    )
+    event_time = timezone.now()
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+    message = None
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "time": event_time.isoformat(),
+        "externalUrl": external_url,
+        "message": message,
+        "availableActions": [TransactionActionEnum.REFUND.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+        $time: DateTime
+        $externalUrl: String
+        $message: String
+        $availableActions: [TransactionActionEnum!]!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+            time: $time
+            externalUrl: $externalUrl
+            message: $message
+            availableActions: $availableActions
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert transaction_report_data["alreadyProcessed"] is False
+
+    event = TransactionEvent.objects.filter(
+        type=TransactionEventType.CHARGE_SUCCESS
+    ).first()
+    assert event
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.created_at == event_time
+    assert event.external_url == external_url
+    assert event.transaction == transaction
+    assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
+    assert event.user is None
+    assert event.message == ""

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -2306,3 +2306,64 @@ def test_for_order_too_long_message_in_response(
         "Value for field: message in response of transaction action webhook "
         "exceeds the character field limit. Message has been truncated."
     ) in [record.message for record in caplog.records]
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_process_session")
+def test_for_order_empty_message(
+    mocked_process,
+    user_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    transaction_item_generator,
+    caplog,
+):
+    # given
+    expected_amount = Decimal("10.00")
+
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    transaction_item = transaction_item_generator(order_id=order.pk, app=webhook_app)
+    TransactionEvent.objects.create(
+        transaction=transaction_item,
+        amount_value=expected_amount,
+        currency=transaction_item.currency,
+        type=TransactionEventType.CHARGE_REQUEST,
+    )
+
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["amount"] = expected_amount
+    expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    expected_response["message"] = None
+    del expected_response["data"]
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "data": None,
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_PROCESS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    _assert_fields(
+        content=content,
+        source_object=order,
+        expected_amount=expected_amount,
+        expected_psp_reference=expected_psp_reference,
+        response_event_type=TransactionEventType.CHARGE_SUCCESS,
+        app_identifier=webhook_app.identifier,
+        mocked_process=mocked_process,
+        charged_value=expected_amount,
+        returned_data=None,
+        expected_message=expected_response["message"],
+    )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3343,3 +3343,44 @@ def test_transaction_uodate_transaction_event_message_limit_exceeded(
     event = transaction.events.last()
     assert event.message == transaction_msg[:509] + "..."
     assert event.psp_reference == transaction_reference
+
+
+def test_transaction_uodate_transaction_event_empty_message(
+    transaction_item_created_by_app,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    transaction = transaction_item_created_by_app
+    transaction_reference = "transaction reference"
+    transaction_msg = None
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction_event": {
+            "pspReference": transaction_reference,
+            "message": transaction_msg,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+    # then
+    event = order_with_lines.events.first()
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]
+
+    assert not data["errors"]
+    assert event.type == OrderEvents.TRANSACTION_EVENT
+    assert event.parameters == {
+        "message": transaction_msg,
+        "reference": transaction_reference,
+    }
+
+    transaction = order_with_lines.payment_transactions.first()
+    event = transaction.events.last()
+    assert event.message == ""
+    assert event.psp_reference == transaction_reference

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -1796,6 +1796,121 @@ def test_create_transaction_event_from_request_and_webhook_response_message_loo_
 
 
 @pytest.mark.parametrize(
+    ("input_message", "expected_message"),
+    [("m" * 512, "m" * 512), (None, ""), ("", ""), (5, "5"), ("你好世界", "你好世界")],
+)
+def test_create_transaction_event_from_request_and_webhook_with_message(
+    input_message, expected_message, transaction_item_generator, app
+):
+    # given
+    transaction = transaction_item_generator()
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=Decimal(11.00),
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_FAILURE
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": input_message,
+        "actions": ["CHARGE", "CHARGE", "CANCEL"],
+    }
+
+    # when
+    event = create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert len(transaction.available_actions) == 2
+    assert set(transaction.available_actions) == set(["charge", "cancel"])
+    assert transaction.events.count() == 2
+    request_event.refresh_from_db()
+    assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
+    assert event
+    assert event.psp_reference == expected_psp_reference
+    assert event.amount_value == event_amount
+    assert event.created_at == datetime.fromisoformat(event_time)
+    assert event.external_url == event_url
+    assert event.message == expected_message
+    assert event.type == event_type
+
+
+class NonParsableObject:
+    def __str__(self):
+        raise "こんにちは".encode("ascii")
+
+
+def test_create_transaction_event_from_request_and_webhook_invalid_message(
+    transaction_item_generator, app, caplog
+):
+    # given
+    transaction = transaction_item_generator()
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.CHARGE_REQUEST,
+        amount_value=Decimal(11.00),
+        currency="USD",
+        transaction_id=transaction.id,
+    )
+
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_FAILURE
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+    input_message = NonParsableObject()
+
+    expected_psp_reference = "psp:122:222"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": input_message,
+        "actions": ["CHARGE", "CHARGE", "CANCEL"],
+    }
+
+    # when
+    event = create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert len(transaction.available_actions) == 2
+    assert set(transaction.available_actions) == set(["charge", "cancel"])
+    assert transaction.events.count() == 2
+    request_event.refresh_from_db()
+    assert request_event.psp_reference == expected_psp_reference
+    assert request_event.include_in_calculations is True
+    assert event
+    assert event.psp_reference == expected_psp_reference
+    assert event.amount_value == event_amount
+    assert event.created_at == datetime.fromisoformat(event_time)
+    assert event.external_url == event_url
+    assert event.message == ""
+    assert event.type == event_type
+    assert (
+        "Incorrect value for field: message in response of transaction action webhook."
+    ) in (record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize(
     ("db_field_name", "value", "event_type"),
     [
         ("authorized_value", Decimal("12"), TransactionEventType.AUTHORIZATION_SUCCESS),
@@ -2585,6 +2700,82 @@ def test_create_transaction_event_message_limit_exceeded(
         "exceeds the character field limit. Message has been truncated."
     )
     assert caplog.records[0].levelno == logging.WARNING
+
+
+@pytest.mark.parametrize(
+    ("input_message", "expected_message"),
+    [("m" * 512, "m" * 512), (None, ""), ("", ""), (5, "5"), ("你好世界", "你好世界")],
+)
+def test_create_transaction_event_with_message(
+    input_message,
+    expected_message,
+    transaction_item_generator,
+    transaction_session_response,
+    webhook_app,
+    plugins_manager,
+    checkout,
+):
+    # given
+    expected_amount = Decimal("15")
+    response = transaction_session_response.copy()
+    response["amount"] = expected_amount
+    response["message"] = input_message
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        transaction=transaction, include_in_calculations=False
+    )
+
+    # when
+    create_transaction_event_for_transaction_session(
+        request_event,
+        webhook_app,
+        manager=plugins_manager,
+        transaction_webhook_response=response,
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert transaction.events.count() == 2
+    event = transaction.events.last()
+    assert event.message == expected_message
+
+
+def test_create_transaction_event_with_invalid_message(
+    transaction_item_generator,
+    transaction_session_response,
+    webhook_app,
+    plugins_manager,
+    checkout,
+    caplog,
+):
+    # given
+    expected_amount = Decimal("15")
+    response = transaction_session_response.copy()
+    response["amount"] = expected_amount
+    response["message"] = NonParsableObject()
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    request_event = TransactionEvent.objects.create(
+        transaction=transaction, include_in_calculations=False
+    )
+
+    # when
+    create_transaction_event_for_transaction_session(
+        request_event,
+        webhook_app,
+        manager=plugins_manager,
+        transaction_webhook_response=response,
+    )
+
+    # then
+    transaction.refresh_from_db()
+    assert transaction.events.count() == 2
+    event = transaction.events.last()
+    assert event.message == ""
+    assert (
+        "Incorrect value for field: message in response of transaction action webhook."
+    ) in (record.message for record in caplog.records)
 
 
 def test_recalculate_refundable_for_checkout_with_request_refund(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -72,6 +72,9 @@ logger = logging.getLogger(__name__)
 
 GENERIC_TRANSACTION_ERROR = "Transaction was unsuccessful"
 ALLOWED_GATEWAY_KINDS = {choices[0] for choices in TransactionKind.CHOICES}
+TRANSACTION_EVENT_MSG_MAX_LENGTH: int = TransactionEvent._meta.get_field(  # type: ignore
+    "message"
+).max_length
 
 
 def _recalculate_last_refund_success_for_transaction(
@@ -880,15 +883,7 @@ def parse_transaction_event_data(
         logger.warning(missing_msg, "result")
         error_field_msg.append(missing_msg % "result")
 
-    message = event_data.get("message", "")
-    if len(message) > 512:
-        message = truncate_message(message)
-        field_limit_exceeded_msg = (
-            "Value for field: %s in response of transaction action webhook "
-            "exceeds the character field limit. Message has been truncated."
-        )
-        logger.warning(field_limit_exceeded_msg, "message")
-    parsed_event_data["message"] = message
+    parsed_event_data["message"] = _clean_message(event_data)
 
     amount_data = event_data.get("amount")
     parse_transaction_event_amount(
@@ -920,6 +915,28 @@ def parse_transaction_event_data(
         parsed_event_data["time"] = timezone.now()
 
     parsed_event_data["external_url"] = event_data.get("externalUrl", "")
+
+
+def _clean_message(event_data):
+    message = event_data.get("message") or ""
+    try:
+        message = str(message)
+    except (UnicodeEncodeError, TypeError, ValueError):
+        invalid_err_msg = (
+            "Incorrect value for field: %s in response of transaction action webhook."
+        )
+        logger.warning(invalid_err_msg, "message")
+        message = ""
+
+    if message and len(message) > TRANSACTION_EVENT_MSG_MAX_LENGTH:
+        message = truncate_transaction_event_message(message)
+        field_limit_exceeded_msg = (
+            "Value for field: %s in response of transaction action webhook "
+            "exceeds the character field limit. Message has been truncated."
+        )
+        logger.warning(field_limit_exceeded_msg, "message")
+
+    return message
 
 
 error_msg = str
@@ -964,7 +981,7 @@ def parse_transaction_action_data(
         # error field msg can contain details of the value returned by payment app
         # which means that we need to confirm that we don't exceed the field limit.
         msg = "\n".join(error_field_msg)
-        msg = truncate_message(msg)
+        msg = truncate_transaction_event_message(msg)
         return None, msg
 
     request_event_type = parsed_event_data.get("type", request_type)
@@ -985,8 +1002,12 @@ def parse_transaction_action_data(
     )
 
 
-def truncate_message(message: str):
-    return message[:509] + "..." if len(message) > 512 else message
+def truncate_transaction_event_message(message: str):
+    return (
+        message[: TRANSACTION_EVENT_MSG_MAX_LENGTH - 3] + "..."
+        if len(message) > TRANSACTION_EVENT_MSG_MAX_LENGTH
+        else message
+    )
 
 
 def get_failed_transaction_event_type_for_request_event(


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17061

Fix truncating the transaction event message in case the message is `None`

Related PR: https://github.com/saleor/saleor/pull/17049/files#diff-d236b14a274fe4e7a0a8db63f9fbfd0b39e61484e371e5410fd32250fcde75ba

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https:/...